### PR TITLE
EQS-547: Remove deprecated setup-python-dependencies option in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,6 @@ jobs:
           # For more details on CodeQL's query packs, refer to:
           # https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
-          setup-python-dependencies: false
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->
### Motivation and Context

In this PR, the deprecated `setup-python-dependencies` option from CodeQL GitHub Actions workflows is removed as advised by GitHub. This resolves warning messages and ensures future compatibility.

### What has changed

- Removal of the `setup-python-dependencies` option from `codeql.yml`. 

### How to review?

- Check if warnings present in the `Initialize CodeQL` step in both Python & Actions CodeQL Actions steps are no longer outputted
- **Optional**: Create your own draft PR with this change to check the CodeQL warnings have disappeared

(Note: Check other existing PRs to see the warning)

### Links

[Link to ticket](https://officefornationalstatistics.atlassian.net/browse/EQS-547)